### PR TITLE
Make uvloop optional on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This repository contains a Python script that continuously gathers proxies from 
 - Python 3
 - `requests` library (`pip install requests`)
 - `beautifulsoup4` (`pip install beautifulsoup4`)
-- `uvloop` (`pip install uvloop`) for best performance
+- `uvloop` (`pip install uvloop`) for best performance on Unix-like systems
+  (optional and not supported on Windows)
 
 ## Usage
 Run the scraper:

--- a/scrape_proxies.py
+++ b/scrape_proxies.py
@@ -5,11 +5,19 @@ import random
 import re
 import base64
 import asyncio
-try:
-    import uvloop
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-except Exception:
+import sys
+
+if sys.platform != "win32":
+    try:
+        import uvloop
+    except Exception:
+        uvloop = None
+    else:
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+else:
     uvloop = None
+    if hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 from functools import lru_cache
 import os
 import socket


### PR DESCRIPTION
## Summary
- only use uvloop on non-Windows OSes
- use `WindowsSelectorEventLoopPolicy` on Windows
- document that uvloop is optional and unsupported on Windows

## Testing
- `pip install aiofiles`
- `pip install requests beautifulsoup4 aiohttp orjson aiofiles aiodns pybloom-live regex`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508ab623bc832c86e817e75f2eb9e2