### PR TITLE
Fix DHT multiprocessing on Windows

### DIFF
--- a/scrape_proxies.py
+++ b/scrape_proxies.py
@@ -2524,10 +2524,15 @@ async def crawl_dht() -> None:
     await asyncio.gather(*workers)
 
 
+def _run_crawl_dht() -> None:
+    """Wrapper to execute crawl_dht inside a child process."""
+    asyncio.run(crawl_dht())
+
+
 def spawn_dht_processes() -> list[multiprocessing.Process]:
     procs = []
     for _ in range(DHT_PROCESSES):
-        p = multiprocessing.Process(target=lambda: asyncio.run(crawl_dht()))
+        p = multiprocessing.Process(target=_run_crawl_dht)
         p.start()
         procs.append(p)
     return procs


### PR DESCRIPTION
## Summary
- fix DHT crawler process spawning on Windows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d2f94734832c9e3c930d4e30cb3b