### PR TITLE
Fix dynamic pool limit adjustment

### DIFF
--- a/scrape_proxies.py
+++ b/scrape_proxies.py
@@ -938,7 +938,11 @@ def adjust_pool_limit(success_rate: float) -> None:
     elif success_rate > 0.7 and POOL_LIMIT < MAX_POOL_LIMIT:
         POOL_LIMIT = min(MAX_POOL_LIMIT, POOL_LIMIT + 5)
     if aiohttp_session is not None:
-        aiohttp_session.connector.limit = POOL_LIMIT
+        # ``aiohttp`` exposes ``connector.limit`` as a read-only property, so we
+        # update the underlying attribute directly.  This avoids ``AttributeError``
+        # when adjusting the pool size at runtime.
+        if hasattr(aiohttp_session.connector, "_limit"):
+            aiohttp_session.connector._limit = POOL_LIMIT
     STATS["peak_concurrency"] = max(STATS.get("peak_concurrency", 0), POOL_LIMIT)
 
 


### PR DESCRIPTION
## Summary
- update `adjust_pool_limit` to avoid AttributeError when changing aiohttp connector limit
- add direct update of the private `_limit` attribute with explanatory comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d74584b0832ca5249ebcb8310965