### PR TITLE
Enhance proxy validation and scoring

### DIFF
--- a/data/allow_lists.json
+++ b/data/allow_lists.json
@@ -1,0 +1,4 @@
+{
+    "countries": ["IT"],
+    "asns": []
+}


### PR DESCRIPTION
## Summary
- validate POP3 banner and STAT RTT in filter_p1 with retry logic
- log TLS cipher suite and SNI
- load ASN and country allow lists from `data/allow_lists.json`
- track freshness per proxy via EWMA

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851f91c7070832cbbc77db2b7865a5f