### PR TITLE
Enhance proxy tool with TLS checks and stats

### DIFF
--- a/scrape_proxies.py
+++ b/scrape_proxies.py
@@ -8,8 +8,12 @@ import json
 import gzip
 import ssl
 import functools
+import signal
+import time
+import argparse
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, AsyncGenerator, Any
+from typing import List, AsyncGenerator, Any, Dict
 
 __all__ = [
     "fetch_proxies",
@@ -31,7 +35,13 @@ __all__ = [
     "CRITICAL_MIN",
     "OVERALL_MIN",
     "WEIGHTS",
-    "filter_p2",
+    "filter1",
+    "scrape",
+    "classify",
+    "check_tls",
+    "write_files",
+    "print_stats",
+    "main",
 ]
 
 _log = logging.getLogger(__name__)
@@ -88,6 +98,35 @@ load_scoring_config()
 # Utility helpers
 # ---------------------------------------------------------------------------
 PROTOCOL_RE = re.compile(r"^(https?|socks4|socks5)$", re.I)
+
+TYPES = ["http", "https", "socks4", "socks5"]
+
+
+@dataclass
+class Stats:
+    """In-memory counters for proxy scraping and testing."""
+
+    total: int = 0
+    passed_filter1: int = 0
+    per_type: Dict[str, int] = field(default_factory=lambda: {t: 0 for t in TYPES})
+    working: Dict[str, int] = field(default_factory=lambda: {t: 0 for t in TYPES})
+    dead: Dict[str, int] = field(default_factory=lambda: {t: 0 for t in TYPES})
+    start: float = field(default_factory=time.monotonic)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "total": self.total,
+            "passed_filter1": self.passed_filter1,
+            "types": {
+                t: {
+                    "total": self.per_type[t],
+                    "working": self.working[t],
+                    "dead": self.dead[t],
+                }
+                for t in TYPES
+            },
+            "elapsed": time.monotonic() - self.start,
+        }
 
 @functools.lru_cache(maxsize=100000)
 def normalize_proxy(entry: str) -> str | None:
@@ -358,45 +397,33 @@ class ProxySpider(Spider):
                 f.write(p + "\n")
 
 # ---------------------------------------------------------------------------
-# Scoring helpers used by filter_p2
+# Scoring helpers used by filter1
 # ---------------------------------------------------------------------------
+
 async def load_blacklists() -> None:
     return None
+
 
 async def _score_single_proxy(p: str, ctx: ssl.SSLContext, return_all: bool = False):
     return None
 
-async def filter_p2(proxies: List[str]) -> tuple[List[tuple[str, int]], List[tuple[str, int]]]:
-    proxies = [p for p in proxies if p.split(":", 1)[0].lower() in {"socks4", "socks5"}]
-    if not proxies:
-        return [], []
-    await load_blacklists()
-    ctx = ssl.create_default_context()
-    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
 
-    async def score(p: str) -> tuple[str, int, dict[str, int]]:
-        res = await _score_single_proxy(p, ctx, return_all=True)
-        assert res is not None
-        return res
+async def filter1(proxies: List[str], timeout: float = 5.0, concurrency: int = 5000) -> List[str]:
+    """Return list of proxies that pass the TLS reachability check."""
 
-    tasks = [asyncio.create_task(score(p)) for p in proxies]
-    scored: List[tuple[str, int, dict[str, int]]] = []
+    sem = asyncio.Semaphore(concurrency)
+    good: List[str] = []
+
+    async def worker(p: str) -> None:
+        proto, host, port = p.split(":", 2)
+        async with sem:
+            if await check_tls(f"{host}:{port}", proto, timeout):
+                good.append(p)
+
+    tasks = [asyncio.create_task(worker(p)) for p in proxies]
     for t in asyncio.as_completed(tasks):
-        try:
-            res = await t
-            if res:
-                scored.append(res)
-        except Exception:
-            continue
-    accepted: List[tuple[str, int]] = []
-    quarantine: List[tuple[str, int]] = []
-    for norm, score, parts in scored:
-        crit = parts.get("critical", 0)
-        if score >= OVERALL_MIN and crit >= CRITICAL_MIN:
-            accepted.append((norm, score))
-        elif MODE == "lenient" and 500 <= score < 600:
-            quarantine.append((norm, score))
-    return accepted, quarantine
+        await t
+    return good
 
 # ---------------------------------------------------------------------------
 # Minimal async fetcher using HTTP sources
@@ -557,3 +584,169 @@ async def probe_proxies(proxies: List[str], concurrency: int = 10000, timeout: f
         fh.close()
 
     return counts
+
+
+def _check_tls_sync(proxy: str, ptype: str, timeout: float, host: str, port: int) -> bool:
+    try:
+        import socks  # type: ignore
+    except Exception as exc:  # pragma: no cover - missing dependency
+        raise RuntimeError("PySocks required") from exc
+
+    addr = _split_host_port(proxy)
+    if not addr:
+        return False
+    phost, pport = addr
+    sock = socks.socksocket()
+    if ptype == "socks5":
+        sock.set_proxy(socks.SOCKS5, phost, pport)
+    elif ptype == "socks4":
+        sock.set_proxy(socks.SOCKS4, phost, pport)
+    elif ptype in {"http", "https"}:
+        sock.set_proxy(socks.HTTP, phost, pport)
+    sock.settimeout(timeout)
+    try:
+        sock.connect((host, port))
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+        wrapped = ctx.wrap_socket(sock, server_hostname=host)
+        wrapped.settimeout(timeout)
+        wrapped.do_handshake()
+        wrapped.close()
+        return True
+    except Exception:
+        try:
+            sock.close()
+        finally:
+            return False
+
+
+async def check_tls(
+    proxy: str,
+    ptype: str,
+    timeout: float = 5.0,
+    target_host: str = "pop.libero.it",
+    target_port: int = 995,
+) -> bool:
+    """Return True if TLS handshake to target succeeds via *proxy*."""
+
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        None, _check_tls_sync, proxy, ptype, timeout, target_host, target_port
+    )
+
+
+async def scrape() -> List[str]:
+    """Collect proxies from all configured sources."""
+
+    data = await collect_proxies_by_type()
+    proxies: List[str] = []
+    for lst in data.values():
+        proxies.extend(lst)
+    return proxies
+
+
+async def classify(proxies: List[str], timeout: float = 2.0) -> List[str]:
+    """Return normalized proxies with detected protocol."""
+
+    result: List[str] = []
+    sem = asyncio.Semaphore(1000)
+
+    async def worker(p: str) -> None:
+        async with sem:
+            kind = await classify_proxy(p, timeout)
+        if kind:
+            result.append(f"{kind}:{p}")
+
+    tasks = [asyncio.create_task(worker(p)) for p in proxies]
+    for t in asyncio.as_completed(tasks):
+        await t
+    return result
+
+
+def write_files(files: Dict[str, Any]) -> None:
+    for fh in files.values():
+        fh.flush()
+        fh.close()
+
+
+async def print_stats(stats: Stats, path: Path) -> None:
+    summary = [f"Total: {stats.total}"]
+    for t in TYPES:
+        summary.append(
+            f"{t}: {stats.per_type[t]} (" \
+            f"{stats.working[t]} working / {stats.dead[t]} dead)"
+        )
+    summary.append(f"Passed filter1: {stats.passed_filter1}")
+    print("[Stats] " + " | ".join(summary))
+    with open(path / "stats.json", "w") as fh:
+        json.dump(stats.to_dict(), fh, indent=2)
+
+
+async def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Proxy scraper")
+    parser.add_argument("--timeout", type=float, default=5.0, help="TLS handshake timeout")
+    parser.add_argument("--concurrency", type=int, default=5000, help="Maximum simultaneous checks")
+    parser.add_argument("--stats-interval", type=float, default=1.0, help="Seconds between stats output")
+    parser.add_argument("--output-dir", type=str, default=".", help="Directory for output files")
+    args = parser.parse_args(argv)
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    files = {t: open(out_dir / f"{t}.txt", "a", buffering=1) for t in TYPES}
+    working_files = {t: open(out_dir / f"{t}_working.txt", "a", buffering=1) for t in TYPES}
+
+    stats = Stats()
+    stop = False
+
+    def _sigint(*_: Any) -> None:
+        nonlocal stop
+        stop = True
+
+    signal.signal(signal.SIGINT, _sigint)
+
+    proxies = await scrape()
+
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    for p in proxies:
+        queue.put_nowait(p)
+
+    sem = asyncio.Semaphore(args.concurrency)
+
+    async def worker() -> None:
+        while not stop:
+            try:
+                proxy = queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+
+            stats.total += 1
+            async with sem:
+                kind = await classify_proxy(proxy, timeout=2.0)
+            if not kind:
+                continue
+            stats.per_type[kind] += 1
+            files[kind].write(f"{proxy}\n")
+            ok = await check_tls(proxy, kind, args.timeout)
+            if ok:
+                stats.working[kind] += 1
+                stats.passed_filter1 += 1
+                working_files[kind].write(f"{proxy}\n")
+            else:
+                stats.dead[kind] += 1
+
+    workers = [asyncio.create_task(worker()) for _ in range(args.concurrency)]
+
+    async def stats_loop() -> None:
+        while any(not w.done() for w in workers):
+            await asyncio.sleep(args.stats_interval)
+            await print_stats(stats, out_dir)
+        await print_stats(stats, out_dir)
+
+    await asyncio.gather(asyncio.create_task(stats_loop()), *workers)
+
+    write_files(files)
+    write_files(working_files)
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,8 @@ import gzip
 import os
 import sys
 import types
+import ssl
+import json
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
@@ -20,7 +22,56 @@ if not hasattr(aiofiles, 'BaseFile'):
         pass
     aiofiles.BaseFile = _BF  # type: ignore
 
-from scrape_proxies import normalize_proxy, _write_gzip, bencode, bdecode
+from scrape_proxies import normalize_proxy, _write_gzip, bencode, bdecode, check_tls
+
+CERT = """-----BEGIN CERTIFICATE-----
+MIIDCTCCAfGgAwIBAgIUavROruD4wmEVjyoQgGzCgLukod0wDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI1MDYxOTE0NTU1M1oXDTI1MDYy
+MDE0NTU1M1owFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAypp1RMUhdfGJ5oAicFsgPZ2ERtWuSdx9Z2JMWjHe6eEX
+MIEesz/KWQHCRHUeKLuLuL6lisbD7sRj+bRvd4qNdjIWY2R7NU+jF1Ut9WiE81mS
+o9yp0HEDjz122FwtQMizU30UVVtI0gi7br53RvzmFYh0zy2ciXeJWsKtbvseK3QZ
+9G+d8EUHlU8FnqKT2QdosqaUpgeBQ7QpgzdGpxnAoPAk3SS06HkiMxCgaSfVANFs
+g2Ca0QMYq/0uPC/m1fAHNIIXcDXTlyOEJxFTTIYvWuJXXfuXortOw2v/Ll3ilcQ6
+KSGUYNv/xuhrpJFIUTHZ4svh/Z6hjkLnkO5Aebvq5QIDAQABo1MwUTAdBgNVHQ4E
+FgQU4cliSsl1T4AwxJyBc0GteHlyPrQwHwYDVR0jBBgwFoAU4cliSsl1T4AwxJyB
+c0GteHlyPrQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAwYWF
+ADmg1fVWONEVtKdnXYN4XNVcGRVpmeW2bmB85zF6uvFwB8cmQnwjuII0aZKb8ORC
+Np16VR1vBfeYSReN0dt3NWpqZqxGEmFbKRkvZUexgNpU296ykfqHQmwWlzBvV2iS
+TnHGpGdbLFGxBar2/YF1XiKKnr1Go6mrw2KE36IJwBaLAmVwfKbULEkWo0DumimC
+zSNN9KA/PMnAWx4BkJCzo4LPLxwKpCBb1i4ODw03w4mOm6dqcrJzcAcSvZbfXUja
+qYixulCFjKS/WNwhaTqvVxV7bK5xSAMGMyi68FFHBj/sy9DQEe2+tZvEKEasK2Yz
+yDXfN9zjImgVh+q05g==
+-----END CERTIFICATE-----"""
+
+KEY = """-----BEGIN PRIVATE KEY-----
+MIIEugIBADANBgkqhkiG9w0BAQEFAASCBKQwggSgAgEAAoIBAQDKmnVExSF18Ynm
+gCJwWyA9nYRG1a5J3H1nYkxaMd7p4RcwgR6zP8pZAcJEdR4ou4u4vqWKxsPuxGP5
+tG93io12MhZjZHs1T6MXVS31aITzWZKj3KnQcQOPPXbYXC1AyLNTfRRVW0jSCLtu
+vndG/OYViHTPLZyJd4lawq1u+x4rdBn0b53wRQeVTwWeopPZB2iyppSmB4FDtCmD
+N0anGcCg8CTdJLToeSIzEKBpJ9UA0WyDYJrRAxir/S48L+bV8Ac0ghdwNdOXI4Qn
+EVNMhi9a4ldd+5eiu07Da/8uXeKVxDopIZRg2//G6GukkUhRMdniy+H9nqGOQueQ
+7kB5u+rlAgMBAAECgf90u4nVlb8xtXk+1ZUCJ37sAVW1emhxJhka+AgF77YACzDR
+QZPus1Ji9iB4UQKPdX+LckzvKJa7e2we81dGCQ54i2Na4QocLUZKq0lPnGj9zR4w
+S3OMJZFndoKDJpjsOrcX43lTtMTAP0e/Bv6yaAQpY/XpaN5IVhdNs905lHZNkhDs
+X2TtOb9wr852GlAgvUXSjfDWj1UFYjDSY56NxGcNntwrgqTVHRbjl7pd65hMcHqw
+abx8Gl4+MICxNGgFgaRcGnQFuq9X4oMEbKRO9n0Xsnyi9HuryjAZti6v0Akd70L4
+oppZ/2U/Z+Rq2HZ9R0k3doVI9dADOZ0O0Z4znUECgYEA5s1AxMCta0Vq7ygndTvo
+qhzW0mFesJJdKvF1VZa7hoCiejGmbY1YBh0CkEut7aicS0rKNHnM9hNc+8WKt5gp
+0QVFYl2ayk1b/6TLiIeO14QqpD2+jDWzDHg1iHM4F0nSRRsqbyrkeorAEpyFuy0T
+qQ3kvs79DW+lKRDsZV4wCGECgYEA4LkUQ2fKgf2QWeTZO7fuUgDZtyxcJ1T6o/ZI
+jV3Mg1Uy6mH0n0a5HBTe/7J61nn9+fJ7oKkQNRZbNwIAIdTsHGIC47crmTdvQP2c
+S6rAKAOFOsptbwDzrTkp0uTPfw2D9TfMfp3ti8BoUmVauo2R/2AvntjApmP5gv+w
+2Hf/YQUCgYBg0Kqhnf1g6R6hMaPTnozLhwtp9qRExzDDycOhYnhJRH5jaZ5ZiBfr
+gJHJu6U68yaUwsutVYZvltHDXysANpkb7+0aBQ/gWrEDvLoQDGUT7IICoU/j+saf
+rXEvSr21rybADFQxi7mJ2dgWNog2awM7P/O7QpKN505NuqafIvJdIQKBgFaL8Rnk
+p0FY/ncgg+lT9Rzv5ul81CDxwXXULC0FqvYJogpSn3uYKUJ/Z0Li4hwn74CLusEt
+W2iWq5qL0rE055omxSYeLVRc3SQSiFc787V1ZaI2w960ZySXl1v5c1BjTCbszn0V
+JZ9lAsh48HBYhZns2Wo74DY02qtw/hLgZCJhAoGAOOuOkxKwn8+hjatK4E5TyRn9
+ofh6cVzO7ML2+UcdxypVlDv5wjzvlojBduoWqFrZZU4oYGLFW7q0E+xLMFCdEDkh
+nsrgxxRq3rskPDh+Bkrv/03w+u8/VUFyk9T0QSK8/O31Qv0P5Tuj3pS5oPnvYPzl
+uZ7vo0sZRf7SedYmQ08=
+-----END PRIVATE KEY-----"""
 
 
 def test_normalize_proxy_basic():
@@ -43,3 +94,75 @@ def test_bencode_roundtrip():
     value = {'a': [1, b'2']}
     encoded = bencode(value)
     assert bdecode(encoded) == {b'a': [1, b'2']}
+
+
+def test_main_and_files(monkeypatch, tmp_path):
+    import asyncio
+    import scrape_proxies as sp
+
+    async def fake_collect():
+        return {"HTTP": ["1.1.1.1:1"]}
+
+    async def fake_classify(p, timeout=2.0):
+        return "http"
+
+    recorded = {}
+
+    async def fake_check_tls(proxy, proto, timeout=5.0, **kwargs):
+        recorded["timeout"] = timeout
+        return True
+
+    class FakeSemaphore(asyncio.Semaphore):
+        def __init__(self, value):
+            recorded["concurrency"] = value
+            super().__init__(value)
+
+    monkeypatch.setattr(sp, "collect_proxies_by_type", fake_collect)
+    monkeypatch.setattr(sp, "classify_proxy", fake_classify)
+    monkeypatch.setattr(sp, "check_tls", fake_check_tls)
+    monkeypatch.setattr(sp.asyncio, "Semaphore", FakeSemaphore)
+
+    asyncio.run(sp.main([
+        "--timeout", "3", "--concurrency", "2", "--stats-interval", "0.1", "--output-dir", str(tmp_path)
+    ]))
+
+    assert recorded["timeout"] == 3
+    assert recorded["concurrency"] == 2
+    assert (tmp_path / "http.txt").exists()
+    assert (tmp_path / "http_working.txt").exists()
+    data = json.loads((tmp_path / "stats.json").read_text())
+    assert data["total"] == 1
+    assert data["passed_filter1"] == 1
+
+
+def test_check_tls(tmp_path):
+    import asyncio
+    ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    cert.write_text(CERT)
+    key.write_text(KEY)
+    ssl_ctx.load_cert_chain(cert, key)
+
+    async def handle(reader, writer):
+        await reader.read(1)
+        writer.close()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    server = loop.run_until_complete(
+        asyncio.start_server(handle, "127.0.0.1", 0, ssl=ssl_ctx)
+    )
+    port = server.sockets[0].getsockname()[1]
+
+    try:
+        assert loop.run_until_complete(
+            check_tls(f"127.0.0.1:{port}", "direct", timeout=1, target_host="127.0.0.1", target_port=port)
+        )
+        assert not loop.run_until_complete(
+            check_tls(f"127.0.0.1:{port+1}", "direct", timeout=1, target_host="127.0.0.1", target_port=port+1)
+        )
+    finally:
+        server.close()
+        loop.run_until_complete(server.wait_closed())
+        loop.close()


### PR DESCRIPTION
## Summary
- add Stats dataclass with per-type counters
- implement TLS reachability check and new `filter1`
- stream scraping stats to json and CLI output
- support CLI flags for timeout, concurrency, stats interval, and output dir
- update tests for new behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pysocks`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542437ad8c832cb0e29fc0efc20739