### PR TITLE
Update proxy sources and parsing for JSON

### DIFF
--- a/data/proxy_sources.json
+++ b/data/proxy_sources.json
@@ -33,7 +33,15 @@
     "https://raw.githubusercontent.com/ErcinDedeoglu/proxies/main/proxies/http.txt",
     "https://raw.githubusercontent.com/elliottophellia/yakumo/master/results/http/global/http_checked.txt",
     "https://raw.githubusercontent.com/ProxyScraper/ProxyScraper/refs/heads/main/http.txt",
-    "https://raw.githubusercontent.com/proxifly/free-proxy-list/refs/heads/main/proxies/protocols/http/data.txt"
+    "https://raw.githubusercontent.com/proxifly/free-proxy-list/refs/heads/main/proxies/protocols/http/data.txt",
+    "https://cdn.jsdelivr.net/gh/proxifly/free-proxy-list@main/proxies/protocols/http/data.txt",
+    "https://cdn.jsdelivr.net/gh/databay-labs/free-proxy-list/http.txt",
+    "https://raw.githubusercontent.com/dpangestuw/Free-Proxy/refs/heads/main/http_proxies.txt",
+    "https://raw.githubusercontent.com/casals-ar/proxy-list/main/http",
+    "https://raw.githubusercontent.com/TuanMinPay/live-proxy/master/http.txt",
+    "https://raw.githubusercontent.com/im-razvan/proxy_list/main/http.txt",
+    "https://raw.githubusercontent.com/yemixzy/proxy-list/main/proxies/http.txt",
+    "https://raw.githubusercontent.com/arunsakthivel96/proxyBEE/refs/heads/master/proxy.list"
   ],
   "SOCKS4": [
     "https://api.proxyscrape.com/v2/?request=displayproxies&protocol=socks4",
@@ -59,7 +67,17 @@
     "https://raw.githubusercontent.com/B4RC0DE-TM/proxy-list/main/SOCKS4.txt",
     "https://raw.githubusercontent.com/ErcinDedeoglu/proxies/main/proxies/socks4.txt",
     "https://raw.githubusercontent.com/ProxyScraper/ProxyScraper/refs/heads/main/socks4.txt",
-    "https://raw.githubusercontent.com/proxifly/free-proxy-list/refs/heads/main/proxies/protocols/socks4/data.txt"
+    "https://raw.githubusercontent.com/proxifly/free-proxy-list/refs/heads/main/proxies/protocols/socks4/data.txt",
+    "https://cdn.jsdelivr.net/gh/proxifly/free-proxy-list@main/proxies/protocols/socks4/data.txt",
+    "https://raw.githubusercontent.com/dpangestuw/Free-Proxy/refs/heads/main/socks4_proxies.txt",
+    "https://raw.githubusercontent.com/saschazesiger/Free-Proxies/master/proxies/socks4.txt",
+    "https://raw.githubusercontent.com/TuanMinPay/live-proxy/master/socks4.txt",
+    "https://raw.githubusercontent.com/casals-ar/proxy-list/main/socks4",
+    "https://www.proxy-list.download/api/v1/get?type=socks4",
+    "https://proxyspace.pro/socks4.txt",
+    "https://raw.githubusercontent.com/HyperBeats/proxy-list/main/socks4.txt",
+    "https://raw.githubusercontent.com/zloi-user/hideip.me/main/socks4.txt",
+    "https://github.com/gr8rehanna/proxy/raw/refs/heads/main/proxy.json"
   ],
   "SOCKS5": [
     "https://raw.githubusercontent.com/B4RC0DE-TM/proxy-list/main/SOCKS5.txt",
@@ -82,7 +100,23 @@
     "https://raw.githubusercontent.com/ErcinDedeoglu/proxies/main/proxies/socks5.txt",
     "https://raw.githubusercontent.com/elliottophellia/yakumo/master/results/socks5/global/socks5_checked.txt",
     "https://raw.githubusercontent.com/ProxyScraper/ProxyScraper/refs/heads/main/socks5.txt",
-    "https://raw.githubusercontent.com/proxifly/free-proxy-list/refs/heads/main/proxies/protocols/socks5/data.txt"
+    "https://raw.githubusercontent.com/proxifly/free-proxy-list/refs/heads/main/proxies/protocols/socks5/data.txt",
+    "https://cdn.jsdelivr.net/gh/proxifly/free-proxy-list@main/proxies/protocols/socks5/data.txt",
+    "https://cdn.jsdelivr.net/gh/databay-labs/free-proxy-list/socks5.txt",
+    "https://raw.githubusercontent.com/dpangestuw/Free-Proxy/refs/heads/main/socks5_proxies.txt",
+    "https://api.proxyscrape.com/v2/?request=displayproxies&protocol=socks5",
+    "https://raw.githubusercontent.com/im-razvan/proxy_list/main/socks5.txt",
+    "https://proxyspace.pro/socks5.txt",
+    "https://raw.githubusercontent.com/zloi-user/hideip.me/main/socks5.txt",
+    "https://raw.githubusercontent.com/HyperBeats/proxy-list/main/socks5.txt",
+    "https://raw.githubusercontent.com/TuanMinPay/live-proxy/master/socks5.txt",
+    "https://raw.githubusercontent.com/saschazesiger/Free-Proxies/master/proxies/socks5.txt",
+    "https://api.proxyscrape.com/?request=displayproxies&proxytype=socks5",
+    "https://raw.githubusercontent.com/manuGMG/proxy-365/main/SOCKS5.txt",
+    "https://raw.githubusercontent.com/casals-ar/proxy-list/main/socks5",
+    "https://raw.githubusercontent.com/ALIILAPRO/Proxy/main/socks5.txt",
+    "https://raw.githubusercontent.com/Zaeem20/FREE_PROXIES_LIST/master/socks5.txt",
+    "https://github.com/gr8rehanna/proxy/raw/refs/heads/main/proxy.json"
   ],
   "HTTPS": [
     "https://raw.githubusercontent.com/jetkai/proxy-list/main/online-proxies/txt/proxies-https.txt",
@@ -92,6 +126,11 @@
     "https://raw.githubusercontent.com/Anonym0usWork1221/Free-Proxies/main/proxy_files/https_proxies.txt",
     "https://raw.githubusercontent.com/officialputuid/KangProxy/KangProxy/https/https.txt",
     "https://raw.githubusercontent.com/ErcinDedeoglu/proxies/main/proxies/https.txt",
-    "https://raw.githubusercontent.com/proxifly/free-proxy-list/refs/heads/main/proxies/protocols/https/data.txt"
+    "https://raw.githubusercontent.com/proxifly/free-proxy-list/refs/heads/main/proxies/protocols/https/data.txt",
+    "https://cdn.jsdelivr.net/gh/databay-labs/free-proxy-list/https.txt",
+    "https://raw.githubusercontent.com/claude89757/free_https_proxies/refs/heads/main/https_proxies.txt",
+    "https://raw.githubusercontent.com/mmpx12/proxy-list/master/https.txt",
+    "https://raw.githubusercontent.com/roosterkid/openproxylist/main/HTTPS_RAW.txt",
+    "https://raw.githubusercontent.com/casals-ar/proxy-list/main/https"
   ]
 }

--- a/proxy_sources.json
+++ b/proxy_sources.json
@@ -1,6 +1,24 @@
 {
-    "HTTP": ["https://example.com/http.txt"],
-    "HTTPS": ["https://example.com/https.txt"],
-    "SOCKS4": ["https://example.com/socks4.txt"],
-    "SOCKS5": ["https://example.com/socks5.txt"]
+  "HTTP": [
+    "https://example.com/http.txt",
+    "https://cdn.jsdelivr.net/gh/proxifly/free-proxy-list@main/proxies/protocols/http/data.txt",
+    "https://cdn.jsdelivr.net/gh/databay-labs/free-proxy-list/http.txt",
+    "https://raw.githubusercontent.com/dpangestuw/Free-Proxy/refs/heads/main/http_proxies.txt"
+  ],
+  "HTTPS": [
+    "https://example.com/https.txt",
+    "https://cdn.jsdelivr.net/gh/databay-labs/free-proxy-list/https.txt",
+    "https://raw.githubusercontent.com/claude89757/free_https_proxies/refs/heads/main/https_proxies.txt"
+  ],
+  "SOCKS4": [
+    "https://example.com/socks4.txt",
+    "https://cdn.jsdelivr.net/gh/proxifly/free-proxy-list@main/proxies/protocols/socks4/data.txt",
+    "https://raw.githubusercontent.com/dpangestuw/Free-Proxy/refs/heads/main/socks4_proxies.txt"
+  ],
+  "SOCKS5": [
+    "https://example.com/socks5.txt",
+    "https://cdn.jsdelivr.net/gh/proxifly/free-proxy-list@main/proxies/protocols/socks5/data.txt",
+    "https://cdn.jsdelivr.net/gh/databay-labs/free-proxy-list/socks5.txt",
+    "https://raw.githubusercontent.com/dpangestuw/Free-Proxy/refs/heads/main/socks5_proxies.txt"
+  ]
 }


### PR DESCRIPTION
## Summary
- extend proxy source lists with many additional URLs
- parse JSON proxy lists when scraping sources
- support new sources in default config files

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pysocks`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68544e789664832c89457b336082f780