### PR TITLE
Fix aiohttp session cleanup

### DIFF
--- a/tests/test_proxxy_sources.py
+++ b/tests/test_proxxy_sources.py
@@ -39,9 +39,14 @@ def test_fetch_proxxy_sources(monkeypatch):
     sp = importlib.import_module("scrape_proxies")
     monkeypatch.setattr(sp, "PROXXY_SOURCES", {"HTTP": ["http://example.com"]})
 
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
     async def fake_session():
-        text = "http://1.1.1.1:1\ninvalid\n2.2.2.2:2 extra\n[2001:db8::1]:8080"
-        return FakeSession(text)
+        text = (
+            "http://1.1.1.1:1\ninvalid\n2.2.2.2:2 extra\n[2001:db8::1]:8080"
+        )
+        yield FakeSession(text)
 
     monkeypatch.setattr(sp, "get_aiohttp_session", fake_session)
 
@@ -76,8 +81,11 @@ def test_collect_proxies_by_type(monkeypatch, tmp_path):
     }
     monkeypatch.setattr(sp, "PROXXY_SOURCES", {"HTTP": ["http://h"], "SOCKS5": ["http://s5"]})
 
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
     async def fake_session():
-        return MapSession(mapping)
+        yield MapSession(mapping)
 
     monkeypatch.setattr(sp, "get_aiohttp_session", fake_session)
 
@@ -98,8 +106,11 @@ def test_dedup_across_sources(monkeypatch):
     }
     monkeypatch.setattr(sp, "PROXXY_SOURCES", {"HTTP": ["http://a", "http://b"]})
 
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
     async def fake_session():
-        return MapSession(mapping)
+        yield MapSession(mapping)
 
     monkeypatch.setattr(sp, "get_aiohttp_session", fake_session)
 


### PR DESCRIPTION
## Summary
- make `get_aiohttp_session` return an async context manager
- manage `aiohttp.ClientSession` lifetime with `async with`
- adjust tests for the new context manager behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549b564af4832c8802c0d7b6641624